### PR TITLE
Test append env instead of override

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -3,6 +3,7 @@ var fs = require('fs');
 var assert = require('assert');
 var os = require('os');
 var child_process = require('child_process');
+var util = require('util');
 
 exports.testDir = path.dirname(__filename);
 exports.fixturesDir = path.join(exports.testDir, 'fixtures');
@@ -118,7 +119,6 @@ exports.hasIPv6 = Object.keys(ifaces).some(function(name) {
   });
 });
 
-var util = require('util');
 for (var i in util) exports[i] = util[i];
 //for (var i in exports) global[i] = exports[i];
 
@@ -406,4 +406,8 @@ exports.fileExists = function(pathname) {
   } catch (err) {
     return false;
   }
+};
+
+exports.extendEnv = function(env) {
+  return util._extend(process.env, env);
 };

--- a/test/parallel/test-child-process-spawnsync-env.js
+++ b/test/parallel/test-child-process-spawnsync-env.js
@@ -7,7 +7,7 @@ if (process.argv[2] === 'child') {
 } else {
   var expected = 'bar';
   var child = cp.spawnSync(process.execPath, [__filename, 'child'], {
-    env: {foo: expected}
+    env: common.extendEnv({foo: expected})
   });
 
   assert.equal(child.stdout.toString().trim(), expected);

--- a/test/parallel/test-fs-readfile-error.js
+++ b/test/parallel/test-fs-readfile-error.js
@@ -15,7 +15,7 @@ var callbacks = 0;
 function test(env, cb) {
   var filename = path.join(common.fixturesDir, 'test-fs-readfile-error.js');
   var execPath = '"' + process.execPath + '" "' + filename + '"';
-  var options = { env: env || {} };
+  var options = { env: common.extendEnv(env || {}) };
   exec(execPath, options, function(err, stdout, stderr) {
     assert(err);
     assert.equal(stdout, '');

--- a/test/sequential/test-net-GH-5504.js
+++ b/test/sequential/test-net-GH-5504.js
@@ -53,10 +53,9 @@ function parent() {
   var clientExited = false;
   var serverListened = false;
   var opt = {
-    env: {
-      NODE_DEBUG: 'net',
-      NODE_COMMON_PORT: process.env.NODE_COMMON_PORT,
-    }
+    env: common.extendEnv({
+      NODE_DEBUG: 'net'
+    })
   };
 
   process.on('exit', function() {
@@ -104,4 +103,3 @@ function parent() {
     });
   }
 }
-

--- a/test/sequential/test-stdin-script-child.js
+++ b/test/sequential/test-stdin-script-child.js
@@ -3,9 +3,9 @@ var assert = require('assert');
 
 var spawn = require('child_process').spawn;
 var child = spawn(process.execPath, [], {
-  env: {
+  env: common.extendEnv({
     NODE_DEBUG: process.argv[2]
-  }
+  })
 });
 var wanted = child.pid + '\n';
 var found = '';

--- a/test/sequential/test-util-debug.js
+++ b/test/sequential/test-util-debug.js
@@ -31,7 +31,9 @@ function test(environ, shouldWrite) {
     // env variable is passed to the child to make the test pass.
     // this is fixed in the next version of lttng (2.7+), so we can
     // remove it at sometime in the future.
-    env: { NODE_DEBUG: environ, HOME: process.env.HOME }
+    env: common.extendEnv({
+      NODE_DEBUG: environ
+    })
   });
 
   expectErr = expectErr.split('%PID%').join(child.pid);


### PR DESCRIPTION
Issue: https://github.com/nodejs/node/issues/25
From: https://github.com/joyent/node/commit/e64ee2b3f7b4067101b0291f1add842353cd6865

Original commit message:

```
Some tests that rely on some environment variables being passed to child
processes would fail because they reset the child processes'
environement instead of appending to it. This would break on test
environments where some custom environment variables are needed to make
node work properly.
```

This port is modified to move the function into common.js per
https://github.com/nodejs/node/issues/25#issuecomment-104804881
