### PR TITLE
Make http.request correctly parse {host: "hostname:port"}

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -56,8 +56,10 @@ function ClientRequest(options, cb) {
   const defaultPort = options.defaultPort ||
                       self.agent && self.agent.defaultPort;
 
-  var port = options.port = options.port || defaultPort || 80;
-  var host = options.host = options.hostname || options.host || 'localhost';
+  var hostParts = (options.host && options.host.split(':')) || [];
+
+  var port = options.port = options.port || hostParts[1] || defaultPort || 80;
+  var host = options.host = options.hostname || hostParts[0] || 'localhost';
 
   if (options.setHost === undefined) {
     var setHost = true;

--- a/test/parallel/test-http-request-host-port.js
+++ b/test/parallel/test-http-request-host-port.js
@@ -1,0 +1,49 @@
+// Copyright Joyent, Inc. and other Node contributors.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to permit
+// persons to whom the Software is furnished to do so, subject to the
+// following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+// NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+// DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+// OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+// USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+var common = require('../common');
+var assert = require('assert');
+var http = require('http');
+
+var connected = false;
+
+var server = http.createServer(function(req, res) {
+  connected = true;
+  res.writeHead(204);
+  res.end();
+});
+
+server.listen(common.PORT, function() {
+ http.get({
+    host: 'localhost:' + common.PORT
+  }, function(res) {
+    console.log(res.statusCode);
+    res.resume();
+    server.close();
+  }).on('error', function(e) {
+    console.log(e.message);
+    process.exit(1);
+  });
+});
+
+process.on('exit', function() {
+  assert(connected, 'http.request should correctly parse {host: "hostname:port"} and connect to the specified host');
+});


### PR DESCRIPTION
The issue:
`http.request()` treats `host` as an alternate form of `hostname`, which it sort of is, except that `host` is (normally) allowed to contain a port number.

Before this change, if `host` contains a port number and there isn't a `hostname` field to override it, `http.request()` attempts a DNS lookup on the entire host field, including the port number. This always fails.

The fix:
If a host field is present, split it around `':'` and use the first portion as a fallback `hostname` and the second (if present) as a fallback `port`. ("Fallback" meaning that the values from the `host` field are only used when the `hostname` and `port` fields aren't set.)

Includes a test to verify the correct behavior.

I originally filed an [issue](https://github.com/joyent/node/issues/25751) on joyent/node and submitted a [patch](https://github.com/joyent/node/pull/25752) there, but @jasnell said that this might be a better fit for nodejs/io.js or nodejs/node, so I'm sending the same patch to each. (The io.js patch is at https://github.com/nodejs/io.js/pull/2271) Please merge into whichever repo is appropriate and close the other one.
