### PR TITLE
[addons] Implement new init function argument dispatch

### DIFF
--- a/src/async-wrap.cc
+++ b/src/async-wrap.cc
@@ -54,9 +54,7 @@ static void SetupHooks(const FunctionCallbackInfo<Value>& args) {
 }
 
 
-static void Initialize(Handle<Object> target,
-                Handle<Value> unused,
-                Handle<Context> context) {
+static void Initialize(Local<Object> target, Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
   Isolate* isolate = env->isolate();
   HandleScope scope(isolate);
@@ -183,4 +181,4 @@ Handle<Value> AsyncWrap::MakeCallback(const Handle<Function> cb,
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(async_wrap, node::Initialize)
+NODE_MODULE_BUILTIN(async_wrap, node::Initialize)

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -1216,9 +1216,7 @@ static void CaresTimerClose(Environment* env,
 }
 
 
-static void Initialize(Handle<Object> target,
-                       Handle<Value> unused,
-                       Handle<Context> context) {
+static void Initialize(Local<Object> target, Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
 
   int r = ares_library_init(ARES_LIB_INIT_ALL);
@@ -1292,6 +1290,8 @@ static void Initialize(Handle<Object> target,
 }
 
 }  // namespace cares_wrap
+
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(cares_wrap, node::cares_wrap::Initialize)
+NODE_MODULE_BUILTIN(cares_wrap, node::cares_wrap::Initialize)
+

--- a/src/fs_event_wrap.cc
+++ b/src/fs_event_wrap.cc
@@ -24,9 +24,7 @@ using v8::Value;
 
 class FSEventWrap: public HandleWrap {
  public:
-  static void Initialize(Handle<Object> target,
-                         Handle<Value> unused,
-                         Handle<Context> context);
+  static void Initialize(Local<Object> target, Local<Context> context);
   static void New(const FunctionCallbackInfo<Value>& args);
   static void Start(const FunctionCallbackInfo<Value>& args);
   static void Close(const FunctionCallbackInfo<Value>& args);
@@ -57,9 +55,7 @@ FSEventWrap::~FSEventWrap() {
 }
 
 
-void FSEventWrap::Initialize(Handle<Object> target,
-                             Handle<Value> unused,
-                             Handle<Context> context) {
+void FSEventWrap::Initialize(Local<Object> target, Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
 
   Local<FunctionTemplate> t = env->NewFunctionTemplate(New);
@@ -174,4 +170,4 @@ void FSEventWrap::Close(const FunctionCallbackInfo<Value>& args) {
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(fs_event_wrap, node::FSEventWrap::Initialize)
+NODE_MODULE_BUILTIN(fs_event_wrap, node::FSEventWrap::Initialize)

--- a/src/js_stream.cc
+++ b/src/js_stream.cc
@@ -194,9 +194,7 @@ void JSStream::EmitEOF(const FunctionCallbackInfo<Value>& args) {
 }
 
 
-void JSStream::Initialize(Handle<Object> target,
-                          Handle<Value> unused,
-                          Handle<Context> context) {
+void JSStream::Initialize(Local<Object> target, Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
 
   Local<FunctionTemplate> t = env->NewFunctionTemplate(New);
@@ -219,4 +217,5 @@ void JSStream::Initialize(Handle<Object> target,
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(js_stream, node::JSStream::Initialize)
+NODE_MODULE_BUILTIN(js_stream, node::JSStream::Initialize)
+

--- a/src/js_stream.h
+++ b/src/js_stream.h
@@ -10,9 +10,8 @@ namespace node {
 
 class JSStream : public StreamBase, public AsyncWrap {
  public:
-  static void Initialize(v8::Handle<v8::Object> target,
-                         v8::Handle<v8::Value> unused,
-                         v8::Handle<v8::Context> context);
+  static void Initialize(v8::Local<v8::Object> target,
+                         v8::Local<v8::Context> context);
 
   ~JSStream();
 

--- a/src/node.cc
+++ b/src/node.cc
@@ -2091,6 +2091,10 @@ void DLOpen(const FunctionCallbackInfo<Value>& args) {
     env->ThrowError("Built-in module self-registered.");
     return;
   }
+  if (mp->nm_flags & NM_F_NODE_MODULE_CONTEXT_AWARE_IS_DEPRECATED) {
+    fprintf(stderr, "NODE_MODULE_CONTEXT_AWARE(...) is deprecated. Use "
+            "NODE_MODULE(...) instead\n");
+  }
 
   mp->nm_dso_handle = lib.handle;
   mp->nm_link = modlist_addon;
@@ -2099,10 +2103,12 @@ void DLOpen(const FunctionCallbackInfo<Value>& args) {
   Local<String> exports_string = env->exports_string();
   Local<Object> exports = module->Get(exports_string)->ToObject(env->isolate());
 
-  if (mp->nm_context_register_func != nullptr) {
-    mp->nm_context_register_func(exports, module, env->context(), mp->nm_priv);
-  } else if (mp->nm_register_func != nullptr) {
-    mp->nm_register_func(exports, module, mp->nm_priv);
+  if (mp->nm_register_func != nullptr) {
+    mp->nm_register_func(mp->nm_init,
+                         exports,
+                         module,
+                         env->context(),
+                         mp->nm_priv);
   } else {
     env->ThrowError("Module has no declared entry point.");
     return;
@@ -2212,12 +2218,13 @@ static void Binding(const FunctionCallbackInfo<Value>& args) {
   node_module* mod = get_builtin_module(*module_v);
   if (mod != nullptr) {
     exports = Object::New(env->isolate());
+    CHECK_NE(mod->nm_register_func, nullptr);
     // Internal bindings don't have a "module" object, only exports.
-    CHECK_EQ(mod->nm_register_func, nullptr);
-    CHECK_NE(mod->nm_context_register_func, nullptr);
-    Local<Value> unused = Undefined(env->isolate());
-    mod->nm_context_register_func(exports, unused,
-      env->context(), mod->nm_priv);
+    mod->nm_register_func(mod->nm_init,
+                          exports,
+                          Undefined(env->isolate()).As<Object>(),
+                          env->context(),
+                          mod->nm_priv);
     cache->Set(module, exports);
   } else if (!strcmp(*module_v, "constants")) {
     exports = Object::New(env->isolate());
@@ -2264,13 +2271,12 @@ static void LinkedBinding(const FunctionCallbackInfo<Value>& args) {
 
   Local<Object> exports = Object::New(env->isolate());
 
-  if (mod->nm_context_register_func != nullptr) {
-    mod->nm_context_register_func(exports,
-                                  module,
-                                  env->context(),
-                                  mod->nm_priv);
-  } else if (mod->nm_register_func != nullptr) {
-    mod->nm_register_func(exports, module, mod->nm_priv);
+  if (mod->nm_register_func != nullptr) {
+    mod->nm_register_func(mod->nm_init,
+                          exports,
+                          Undefined(env->isolate()).As<Object>(),
+                          env->context(),
+                          mod->nm_priv);
   } else {
     return env->ThrowError("Linked module has no declared entry point.");
   }

--- a/src/node.h
+++ b/src/node.h
@@ -328,28 +328,113 @@ NODE_DEPRECATED("Use WinapiErrnoException(isolate, ...)",
 
 const char *signo_string(int errorno);
 
+namespace detail {
 
 typedef void (*addon_register_func)(
-    v8::Handle<v8::Object> exports,
-    v8::Handle<v8::Value> module,
-    void* priv);
+    void * init_function,
+    v8::Local<v8::Object> exports,
+    v8::Local<v8::Object> module,
+    v8::Local<v8::Context> context,
+    void * priv);
 
-typedef void (*addon_context_register_func)(
-    v8::Handle<v8::Object> exports,
-    v8::Handle<v8::Value> module,
-    v8::Handle<v8::Context> context,
-    void* priv);
+// This template is used to select the optional arguments of the addon init
+// function.
+template <typename T> struct OptionalInitArg;
 
-#define NM_F_BUILTIN 0x01
-#define NM_F_LINKED  0x02
+template <>
+struct OptionalInitArg<v8::Local<v8::Object> > {
+  static inline
+  v8::Local<v8::Object>
+  pick(v8::Local<v8::Object> module, v8::Local<v8::Context>, void *) {
+    return module;
+  }
+};
+
+template <>
+struct OptionalInitArg<v8::Local<v8::Context> > {
+  static inline
+  v8::Local<v8::Context>
+  pick(v8::Local<v8::Object>, v8::Local<v8::Context> context, void *) {
+    return context;
+  }
+};
+
+template <>
+struct OptionalInitArg<void*> {
+  static inline
+  void*
+  pick(v8::Local<v8::Object>, v8::Local<v8::Context>, void * private_) {
+    return private_;
+  }
+};
+
+// Template that takes the type of the init function as an argument. The
+// implementation of registerAddon(...) is selected (or generated, if you like)
+// based on the functions signature.
+template <typename F> struct AddonInitAdapter;
+
+// Partial specialization: Allow only function pointers with the following
+// properties:
+//   - returns void
+//   - takes a Local<Object> as first argument (exports)
+//   - takes zero or more additional arguments of arbitrary type
+//
+// To further narrow it down it uses a little bit of SFINAE. It will only match
+// if there is a specialization of OptionalInitArg<> for each additional
+// argument. See registerAddon(...) below. This limits the argument types to:
+//   - Local<Object>   (the module)
+//   - Local<Context>  (the context, duh)
+//   - void*           (the private pointer)
+//
+// The interesting thing about this application of SFINAE is that we use it
+// to trigger a compile-time error: Since the generic version of
+// AddonInitAdapter<> is only declared but never defined, the compiler bails
+// after the substitution failure.
+//
+// (Yes, that's right. This is a varidiac partial template specialization used
+// to implement compile-time reflection on the arguments of a C++ function.
+// Don't worry about it.)
+template <typename... Args>
+struct AddonInitAdapter<void (*)(v8::Local<v8::Object>, Args...)> {
+  typedef void (*init_func)(v8::Local<v8::Object>, Args...);
+
+  static
+  void
+  registerAddon(void * f,
+                v8::Local<v8::Object> exports,
+                v8::Local<v8::Object> module,
+                v8::Local<v8::Context> context,
+                void * priv) {
+    init_func init(reinterpret_cast<init_func>(f));
+    init(exports,
+         OptionalInitArg<Args>::pick(module, context, priv)...);
+  }
+};
+
+// utility function to capture the type F of a function
+template <typename F>
+addon_register_func
+selectAddonRegisterFunction(F f) {
+  return AddonInitAdapter<F>::registerAddon;
+}
+
+}  // end of namespace detail
+
+enum node_module_flags {
+  NM_F_BUILTIN                     = (1<<0),
+  NM_F_LINKED                      = (1<<1),
+  // Used to emit a deprecation warning. Remove once
+  // NODE_MODULE_CONTEXT_AWARE is phased out.
+  NM_F_NODE_MODULE_CONTEXT_AWARE_IS_DEPRECATED = (1<<31)
+};
 
 struct node_module {
   int nm_version;
   unsigned int nm_flags;
   void* nm_dso_handle;
   const char* nm_filename;
-  node::addon_register_func nm_register_func;
-  node::addon_context_register_func nm_context_register_func;
+  node::detail::addon_register_func nm_register_func;
+  void* nm_init;
   const char* nm_modname;
   void* nm_priv;
   struct node_module* nm_link;
@@ -379,7 +464,7 @@ extern "C" NODE_EXTERN void node_module_register(void* mod);
   static void fn(void)
 #endif
 
-#define NODE_MODULE_X(modname, regfunc, priv, flags)                  \
+#define NODE_MODULE_X(modname, initfunc, priv, flags)                 \
   extern "C" {                                                        \
     static node::node_module _module =                                \
     {                                                                 \
@@ -387,8 +472,8 @@ extern "C" NODE_EXTERN void node_module_register(void* mod);
       flags,                                                          \
       NULL,                                                           \
       __FILE__,                                                       \
-      (node::addon_register_func) (regfunc),                          \
-      NULL,                                                           \
+      node::detail::selectAddonRegisterFunction(initfunc),            \
+      reinterpret_cast<void*>(initfunc),                              \
       NODE_STRINGIFY(modname),                                        \
       priv,                                                           \
       NULL                                                            \
@@ -398,33 +483,16 @@ extern "C" NODE_EXTERN void node_module_register(void* mod);
     }                                                                 \
   }
 
-#define NODE_MODULE_CONTEXT_AWARE_X(modname, regfunc, priv, flags)    \
-  extern "C" {                                                        \
-    static node::node_module _module =                                \
-    {                                                                 \
-      NODE_MODULE_VERSION,                                            \
-      flags,                                                          \
-      NULL,                                                           \
-      __FILE__,                                                       \
-      NULL,                                                           \
-      (node::addon_context_register_func) (regfunc),                  \
-      NODE_STRINGIFY(modname),                                        \
-      priv,                                                           \
-      NULL                                                            \
-    };                                                                \
-    NODE_C_CTOR(_register_ ## modname) {                              \
-      node_module_register(&_module);                                 \
-    }                                                                 \
-  }
+#define NODE_MODULE(modname, initfunc)                                \
+  NODE_MODULE_X(modname, initfunc, NULL, 0)
 
-#define NODE_MODULE(modname, regfunc)                                 \
-  NODE_MODULE_X(modname, regfunc, NULL, 0)
+// NOTE(agnat): Deprecated. Just use NODE_MODULE(...)
+#define NODE_MODULE_CONTEXT_AWARE(modname, initfunc)                  \
+  NODE_MODULE_X(modname, initfunc, NULL,                              \
+      NM_F_NODE_MODULE_CONTEXT_AWARE_IS_DEPRECATED)
 
-#define NODE_MODULE_CONTEXT_AWARE(modname, regfunc)                   \
-  NODE_MODULE_CONTEXT_AWARE_X(modname, regfunc, NULL, 0)
-
-#define NODE_MODULE_CONTEXT_AWARE_BUILTIN(modname, regfunc)           \
-  NODE_MODULE_CONTEXT_AWARE_X(modname, regfunc, NULL, NM_F_BUILTIN)   \
+#define NODE_MODULE_BUILTIN(modname, initfunc)                        \
+  NODE_MODULE_X(modname, initfunc, NULL, node::NM_F_BUILTIN)
 
 /*
  * For backward compatibility in add-on modules.

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -738,9 +738,7 @@ void SetupBufferJS(const FunctionCallbackInfo<Value>& args) {
 }
 
 
-void Initialize(Handle<Object> target,
-                Handle<Value> unused,
-                Handle<Context> context) {
+void Initialize(Local<Object> target, Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
 
   env->SetMethod(target, "setupBufferJS", SetupBufferJS);
@@ -768,4 +766,4 @@ void Initialize(Handle<Object> target,
 }  // namespace Buffer
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(buffer, node::Buffer::Initialize)
+NODE_MODULE_BUILTIN(buffer, node::Buffer::Initialize)

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -708,9 +708,7 @@ class ContextifyScript : public BaseObject {
 };
 
 
-void InitContextify(Handle<Object> target,
-                    Handle<Value> unused,
-                    Handle<Context> context) {
+void InitContextify(Local<Object> target, Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
   ContextifyContext::Init(env, target);
   ContextifyScript::Init(env, target);
@@ -718,4 +716,4 @@ void InitContextify(Handle<Object> target,
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(contextify, node::InitContextify);
+NODE_MODULE_BUILTIN(contextify, node::InitContextify);

--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -4979,10 +4979,7 @@ void SetEngine(const FunctionCallbackInfo<Value>& args) {
 
 
 // FIXME(bnoordhuis) Handle global init correctly.
-void InitCrypto(Handle<Object> target,
-                Handle<Value> unused,
-                Handle<Context> context,
-                void* priv) {
+void InitCrypto(Local<Object> target, Local<Context> context) {
   static uv_once_t init_once = UV_ONCE_INIT;
   uv_once(&init_once, InitCryptoOnce);
 
@@ -5027,4 +5024,4 @@ void InitCrypto(Handle<Object> target,
 }  // namespace crypto
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(crypto, node::crypto::InitCrypto)
+NODE_MODULE_BUILTIN(crypto, node::crypto::InitCrypto)

--- a/src/node_crypto.h
+++ b/src/node_crypto.h
@@ -682,7 +682,7 @@ bool EntropySource(unsigned char* buffer, size_t length);
 #ifndef OPENSSL_NO_ENGINE
 void SetEngine(const v8::FunctionCallbackInfo<v8::Value>& args);
 #endif  // !OPENSSL_NO_ENGINE
-void InitCrypto(v8::Handle<v8::Object> target);
+void InitCrypto(v8::Local<v8::Object> target, v8::Local<v8::Context> context);
 
 }  // namespace crypto
 }  // namespace node

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -1117,10 +1117,7 @@ void FSInitialize(const FunctionCallbackInfo<Value>& args) {
   env->set_fs_stats_constructor_function(stats_constructor);
 }
 
-void InitFs(Handle<Object> target,
-            Handle<Value> unused,
-            Handle<Context> context,
-            void* priv) {
+void InitFs(Local<Object> target, Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
 
   // Function which creates a new Stats object.
@@ -1172,4 +1169,4 @@ void InitFs(Handle<Object> target,
 
 }  // end namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(fs, node::InitFs)
+NODE_MODULE_BUILTIN(fs, node::InitFs)

--- a/src/node_file.h
+++ b/src/node_file.h
@@ -6,8 +6,7 @@
 
 namespace node {
 
-void InitFs(v8::Handle<v8::Object> target);
-
+void InitFs(v8::Local<v8::Object> target, v8::Local<v8::Context> context);
 }  // namespace node
 
 #endif  // SRC_NODE_FILE_H_

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -558,10 +558,7 @@ const struct http_parser_settings Parser::settings = {
 };
 
 
-void InitHttpParser(Handle<Object> target,
-                    Handle<Value> unused,
-                    Handle<Context> context,
-                    void* priv) {
+void InitHttpParser(Local<Object> target, Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
   Local<FunctionTemplate> t = env->NewFunctionTemplate(Parser::New);
   t->InstanceTemplate()->SetInternalFieldCount(1);
@@ -600,4 +597,4 @@ void InitHttpParser(Handle<Object> target,
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(http_parser, node::InitHttpParser)
+NODE_MODULE_BUILTIN(http_parser, node::InitHttpParser)

--- a/src/node_http_parser.h
+++ b/src/node_http_parser.h
@@ -7,7 +7,8 @@
 
 namespace node {
 
-void InitHttpParser(v8::Handle<v8::Object> target);
+void InitHttpParser(v8::Local<v8::Object> target,
+                    v8::Local<v8::Context> context);
 
 }  // namespace node
 

--- a/src/node_os.cc
+++ b/src/node_os.cc
@@ -271,9 +271,7 @@ static void GetInterfaceAddresses(const FunctionCallbackInfo<Value>& args) {
 }
 
 
-void Initialize(Handle<Object> target,
-                Handle<Value> unused,
-                Handle<Context> context) {
+void Initialize(Local<Object> target, Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
   env->SetMethod(target, "getHostname", GetHostname);
   env->SetMethod(target, "getLoadAvg", GetLoadAvg);
@@ -291,4 +289,4 @@ void Initialize(Handle<Object> target,
 }  // namespace os
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(os, node::os::Initialize)
+NODE_MODULE_BUILTIN(os, node::os::Initialize)

--- a/src/node_v8.cc
+++ b/src/node_v8.cc
@@ -65,9 +65,7 @@ void SetFlagsFromString(const FunctionCallbackInfo<Value>& args) {
 }
 
 
-void InitializeV8Bindings(Handle<Object> target,
-                          Handle<Value> unused,
-                          Handle<Context> context) {
+void InitializeV8Bindings(Local<Object> target, Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
   env->SetMethod(target, "getHeapStatistics", GetHeapStatistics);
   env->SetMethod(target, "setFlagsFromString", SetFlagsFromString);
@@ -92,4 +90,4 @@ void InitializeV8Bindings(Handle<Object> target,
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(v8, node::InitializeV8Bindings)
+NODE_MODULE_BUILTIN(v8, node::InitializeV8Bindings)

--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -43,8 +43,7 @@ enum node_zlib_mode {
 };
 
 
-void InitZlib(v8::Handle<v8::Object> target);
-
+void InitZlib(Local<Object> target, Local<Context> context);
 
 /**
  * Deflate/Inflate
@@ -570,10 +569,7 @@ class ZCtx : public AsyncWrap {
 };
 
 
-void InitZlib(Handle<Object> target,
-              Handle<Value> unused,
-              Handle<Context> context,
-              void* priv) {
+void InitZlib(Local<Object> target, Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
   Local<FunctionTemplate> z = env->NewFunctionTemplate(ZCtx::New);
 
@@ -633,4 +629,4 @@ void InitZlib(Handle<Object> target,
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(zlib, node::InitZlib)
+NODE_MODULE_BUILTIN(zlib, node::InitZlib)

--- a/src/pipe_wrap.cc
+++ b/src/pipe_wrap.cc
@@ -68,9 +68,7 @@ Local<Object> PipeWrap::Instantiate(Environment* env, AsyncWrap* parent) {
 }
 
 
-void PipeWrap::Initialize(Handle<Object> target,
-                          Handle<Value> unused,
-                          Handle<Context> context) {
+void PipeWrap::Initialize(Local<Object> target, Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
 
   Local<FunctionTemplate> t = env->NewFunctionTemplate(New);
@@ -276,4 +274,4 @@ void PipeWrap::Connect(const FunctionCallbackInfo<Value>& args) {
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(pipe_wrap, node::PipeWrap::Initialize)
+NODE_MODULE_BUILTIN(pipe_wrap, node::PipeWrap::Initialize)

--- a/src/pipe_wrap.h
+++ b/src/pipe_wrap.h
@@ -12,9 +12,8 @@ class PipeWrap : public StreamWrap {
   uv_pipe_t* UVHandle();
 
   static v8::Local<v8::Object> Instantiate(Environment* env, AsyncWrap* parent);
-  static void Initialize(v8::Handle<v8::Object> target,
-                         v8::Handle<v8::Value> unused,
-                         v8::Handle<v8::Context> context);
+  static void Initialize(v8::Local<v8::Object> target,
+                         v8::Local<v8::Context> context);
 
  private:
   PipeWrap(Environment* env,

--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -26,9 +26,7 @@ using v8::Value;
 
 class ProcessWrap : public HandleWrap {
  public:
-  static void Initialize(Handle<Object> target,
-                         Handle<Value> unused,
-                         Handle<Context> context) {
+  static void Initialize(Local<Object> target, Local<Context> context) {
     Environment* env = Environment::GetCurrent(context);
     Local<FunctionTemplate> constructor = env->NewFunctionTemplate(New);
     constructor->InstanceTemplate()->SetInternalFieldCount(1);
@@ -260,4 +258,4 @@ class ProcessWrap : public HandleWrap {
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(process_wrap, node::ProcessWrap::Initialize)
+NODE_MODULE_BUILTIN(process_wrap, node::ProcessWrap::Initialize)

--- a/src/signal_wrap.cc
+++ b/src/signal_wrap.cc
@@ -22,9 +22,7 @@ using v8::Value;
 
 class SignalWrap : public HandleWrap {
  public:
-  static void Initialize(Handle<Object> target,
-                         Handle<Value> unused,
-                         Handle<Context> context) {
+  static void Initialize(Local<Object> target, Local<Context> context) {
     Environment* env = Environment::GetCurrent(context);
     Local<FunctionTemplate> constructor = env->NewFunctionTemplate(New);
     constructor->InstanceTemplate()->SetInternalFieldCount(1);
@@ -89,4 +87,4 @@ class SignalWrap : public HandleWrap {
 }  // namespace node
 
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(signal_wrap, node::SignalWrap::Initialize)
+NODE_MODULE_BUILTIN(signal_wrap, node::SignalWrap::Initialize)

--- a/src/smalloc.cc
+++ b/src/smalloc.cc
@@ -607,9 +607,7 @@ bool HasExternalData(Isolate* isolate, Local<Object> obj) {
 }
 
 
-void Initialize(Handle<Object> exports,
-                Handle<Value> unused,
-                Handle<Context> context) {
+void Initialize(Local<Object> exports, Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
   Isolate* isolate = env->isolate();
 
@@ -652,4 +650,4 @@ void Initialize(Handle<Object> exports,
 }  // namespace smalloc
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(smalloc, node::smalloc::Initialize)
+NODE_MODULE_BUILTIN(smalloc, node::smalloc::Initialize)

--- a/src/spawn_sync.cc
+++ b/src/spawn_sync.cc
@@ -340,9 +340,8 @@ void SyncProcessStdioPipe::CloseCallback(uv_handle_t* handle) {
 }
 
 
-void SyncProcessRunner::Initialize(Handle<Object> target,
-                                   Handle<Value> unused,
-                                   Handle<Context> context) {
+void SyncProcessRunner::Initialize(Local<Object> target,
+                                   Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
   env->SetMethod(target, "spawn", Spawn);
 }
@@ -1039,5 +1038,4 @@ void SyncProcessRunner::KillTimerCloseCallback(uv_handle_t* handle) {
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(spawn_sync,
-  node::SyncProcessRunner::Initialize)
+NODE_MODULE_BUILTIN(spawn_sync, node::SyncProcessRunner::Initialize)

--- a/src/spawn_sync.h
+++ b/src/spawn_sync.h
@@ -129,9 +129,7 @@ class SyncProcessRunner {
   };
 
  public:
-  static void Initialize(Handle<Object> target,
-                         Handle<Value> unused,
-                         Handle<Context> context);
+  static void Initialize(Local<Object> target, Local<Context> context);
   static void Spawn(const FunctionCallbackInfo<Value>& args);
 
  private:

--- a/src/stream_wrap.cc
+++ b/src/stream_wrap.cc
@@ -40,9 +40,7 @@ using v8::Undefined;
 using v8::Value;
 
 
-void StreamWrap::Initialize(Handle<Object> target,
-                            Handle<Value> unused,
-                            Handle<Context> context) {
+void StreamWrap::Initialize(Local<Object> target, Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
 
   Local<FunctionTemplate> sw =
@@ -374,4 +372,4 @@ void StreamWrap::OnAfterWriteImpl(WriteWrap* w, void* ctx) {
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(stream_wrap, node::StreamWrap::Initialize)
+NODE_MODULE_BUILTIN(stream_wrap, node::StreamWrap::Initialize)

--- a/src/stream_wrap.h
+++ b/src/stream_wrap.h
@@ -15,9 +15,8 @@ class StreamWrap;
 
 class StreamWrap : public HandleWrap, public StreamBase {
  public:
-  static void Initialize(v8::Handle<v8::Object> target,
-                         v8::Handle<v8::Value> unused,
-                         v8::Handle<v8::Context> context);
+  static void Initialize(v8::Local<v8::Object> target,
+                         v8::Local<v8::Context> context);
 
   int GetFD() override;
   void* Cast() override;

--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -63,9 +63,7 @@ Local<Object> TCPWrap::Instantiate(Environment* env, AsyncWrap* parent) {
 }
 
 
-void TCPWrap::Initialize(Handle<Object> target,
-                         Handle<Value> unused,
-                         Handle<Context> context) {
+void TCPWrap::Initialize(Local<Object> target, Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
 
   Local<FunctionTemplate> t = env->NewFunctionTemplate(New);
@@ -447,4 +445,4 @@ Local<Object> AddressToJS(Environment* env,
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(tcp_wrap, node::TCPWrap::Initialize)
+NODE_MODULE_BUILTIN(tcp_wrap, node::TCPWrap::Initialize)

--- a/src/tcp_wrap.h
+++ b/src/tcp_wrap.h
@@ -10,9 +10,8 @@ namespace node {
 class TCPWrap : public StreamWrap {
  public:
   static v8::Local<v8::Object> Instantiate(Environment* env, AsyncWrap* parent);
-  static void Initialize(v8::Handle<v8::Object> target,
-                         v8::Handle<v8::Value> unused,
-                         v8::Handle<v8::Context> context);
+  static void Initialize(v8::Local<v8::Object> target,
+                         v8::Local<v8::Context> context);
 
   uv_tcp_t* UVHandle();
 

--- a/src/timer_wrap.cc
+++ b/src/timer_wrap.cc
@@ -25,9 +25,7 @@ const uint32_t kOnTimeout = 0;
 
 class TimerWrap : public HandleWrap {
  public:
-  static void Initialize(Handle<Object> target,
-                         Handle<Value> unused,
-                         Handle<Context> context) {
+  static void Initialize(Local<Object> target, Local<Context> context) {
     Environment* env = Environment::GetCurrent(context);
     Local<FunctionTemplate> constructor = env->NewFunctionTemplate(New);
     constructor->InstanceTemplate()->SetInternalFieldCount(1);
@@ -145,4 +143,4 @@ class TimerWrap : public HandleWrap {
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(timer_wrap, node::TimerWrap::Initialize)
+NODE_MODULE_BUILTIN(timer_wrap, node::TimerWrap::Initialize)

--- a/src/tls_wrap.cc
+++ b/src/tls_wrap.cc
@@ -814,9 +814,7 @@ int TLSWrap::SelectSNIContextCallback(SSL* s, int* ad, void* arg) {
 #endif  // SSL_CTRL_SET_TLSEXT_SERVERNAME_CB
 
 
-void TLSWrap::Initialize(Handle<Object> target,
-                         Handle<Value> unused,
-                         Handle<Context> context) {
+void TLSWrap::Initialize(Local<Object> target, Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
 
   env->SetMethod(target, "wrap", TLSWrap::Wrap);
@@ -848,4 +846,4 @@ void TLSWrap::Initialize(Handle<Object> target,
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(tls_wrap, node::TLSWrap::Initialize)
+NODE_MODULE_BUILTIN(tls_wrap, node::TLSWrap::Initialize)

--- a/src/tls_wrap.h
+++ b/src/tls_wrap.h
@@ -27,9 +27,8 @@ class TLSWrap : public crypto::SSLWrap<TLSWrap>,
  public:
   ~TLSWrap() override;
 
-  static void Initialize(v8::Handle<v8::Object> target,
-                         v8::Handle<v8::Value> unused,
-                         v8::Handle<v8::Context> context);
+  static void Initialize(v8::Local<v8::Object> target,
+                         v8::Local<v8::Context> context);
 
   void* Cast() override;
   int GetFD() override;

--- a/src/tty_wrap.cc
+++ b/src/tty_wrap.cc
@@ -27,9 +27,7 @@ using v8::String;
 using v8::Value;
 
 
-void TTYWrap::Initialize(Handle<Object> target,
-                         Handle<Value> unused,
-                         Handle<Context> context) {
+void TTYWrap::Initialize(Local<Object> target, Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
 
   Local<FunctionTemplate> t = env->NewFunctionTemplate(New);
@@ -140,4 +138,4 @@ TTYWrap::TTYWrap(Environment* env, Handle<Object> object, int fd, bool readable)
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(tty_wrap, node::TTYWrap::Initialize)
+NODE_MODULE_BUILTIN(tty_wrap, node::TTYWrap::Initialize)

--- a/src/tty_wrap.h
+++ b/src/tty_wrap.h
@@ -9,9 +9,8 @@ namespace node {
 
 class TTYWrap : public StreamWrap {
  public:
-  static void Initialize(v8::Handle<v8::Object> target,
-                         v8::Handle<v8::Value> unused,
-                         v8::Handle<v8::Context> context);
+  static void Initialize(v8::Local<v8::Object> target,
+                         v8::Local<v8::Context> context);
 
   uv_tty_t* UVHandle();
 

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -70,9 +70,7 @@ UDPWrap::UDPWrap(Environment* env, Handle<Object> object, AsyncWrap* parent)
 }
 
 
-void UDPWrap::Initialize(Handle<Object> target,
-                         Handle<Value> unused,
-                         Handle<Context> context) {
+void UDPWrap::Initialize(Local<Object> target, Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
 
   Local<FunctionTemplate> t = env->NewFunctionTemplate(New);
@@ -429,4 +427,4 @@ uv_udp_t* UDPWrap::UVHandle() {
 
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(udp_wrap, node::UDPWrap::Initialize)
+NODE_MODULE_BUILTIN(udp_wrap, node::UDPWrap::Initialize)

--- a/src/udp_wrap.h
+++ b/src/udp_wrap.h
@@ -13,9 +13,8 @@ namespace node {
 
 class UDPWrap: public HandleWrap {
  public:
-  static void Initialize(v8::Handle<v8::Object> target,
-                         v8::Handle<v8::Value> unused,
-                         v8::Handle<v8::Context> context);
+  static void Initialize(v8::Local<v8::Object> target,
+                         v8::Local<v8::Context> context);
   static void GetFD(v8::Local<v8::String>,
                     const v8::PropertyCallbackInfo<v8::Value>&);
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/src/uv.cc
+++ b/src/uv.cc
@@ -9,7 +9,7 @@ namespace uv {
 using v8::Context;
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
-using v8::Handle;
+using v8::Local;
 using v8::Integer;
 using v8::Object;
 using v8::String;
@@ -26,9 +26,7 @@ void ErrName(const FunctionCallbackInfo<Value>& args) {
 }
 
 
-void Initialize(Handle<Object> target,
-                Handle<Value> unused,
-                Handle<Context> context) {
+void Initialize(Local<Object> target, Local<Context> context) {
   Environment* env = Environment::GetCurrent(context);
   target->Set(FIXED_ONE_BYTE_STRING(env->isolate(), "errname"),
               env->NewFunctionTemplate(ErrName)->GetFunction());
@@ -43,4 +41,4 @@ void Initialize(Handle<Object> target,
 }  // namespace uv
 }  // namespace node
 
-NODE_MODULE_CONTEXT_AWARE_BUILTIN(uv, node::uv::Initialize)
+NODE_MODULE_BUILTIN(uv, node::uv::Initialize)

--- a/test/addons/async-hello-world/binding.cc
+++ b/test/addons/async-hello-world/binding.cc
@@ -62,7 +62,7 @@ void Method(const FunctionCallbackInfo<Value>& args) {
                 (uv_after_work_cb)AfterAsync);
 }
 
-void init(Handle<Object> exports, Handle<Object> module) {
+void init(Local<Object> exports, Local<Object> module) {
   NODE_SET_METHOD(module, "exports", Method);
 }
 

--- a/test/addons/at-exit/binding.cc
+++ b/test/addons/at-exit/binding.cc
@@ -36,7 +36,7 @@ static void sanity_check(void) {
   assert(at_exit_cb2_called == 2);
 }
 
-void init(Handle<Object> target) {
+void init(Local<Object> exports) {
   AtExit(at_exit_cb1);
   AtExit(at_exit_cb2, cookie);
   AtExit(at_exit_cb2, cookie);

--- a/test/addons/hello-world-function-export/binding.cc
+++ b/test/addons/hello-world-function-export/binding.cc
@@ -9,7 +9,7 @@ void Method(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(String::NewFromUtf8(isolate, "world"));
 }
 
-void init(Handle<Object> exports, Handle<Object> module) {
+void init(Local<Object> exports, Local<Object> module) {
   NODE_SET_METHOD(module, "exports", Method);
 }
 

--- a/test/addons/hello-world/binding.cc
+++ b/test/addons/hello-world/binding.cc
@@ -9,8 +9,8 @@ void Method(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(String::NewFromUtf8(isolate, "world"));
 }
 
-void init(Handle<Object> target) {
-  NODE_SET_METHOD(target, "hello", Method);
+void init(Local<Object> exports) {
+  NODE_SET_METHOD(exports, "hello", Method);
 }
 
 NODE_MODULE(binding, init);

--- a/test/addons/init_signatures/binding.gyp
+++ b/test/addons/init_signatures/binding.gyp
@@ -1,0 +1,25 @@
+{ 'target_defaults': { 'defines': ['NODE_TEST_ADDON_NAME=>(_target_name)']}
+, 'targets':
+  [ { 'target_name': 'init_exports'
+    , 'sources'    : ['init_exports.cc']
+    }
+  , { 'target_name': 'init_exports_module'
+    , 'sources'    : ['init_exports_module.cc']
+    }
+  , { 'target_name': 'init_exports_context'
+    , 'sources'    : ['init_exports_context.cc']
+    }
+  , { 'target_name': 'init_exports_private'
+    , 'sources'    : ['init_exports_private.cc']
+    }
+  , { 'target_name': 'init_exports_module_private'
+    , 'sources'    : ['init_exports_module_private.cc']
+    }
+  , { 'target_name': 'init_exports_module_context'
+    , 'sources'    : ['init_exports_module_context.cc']
+    }
+  , { 'target_name': 'init_exports_module_context_private'
+    , 'sources'    : ['init_exports_module_context_private.cc']
+    }
+  ]
+}

--- a/test/addons/init_signatures/init_exports.cc
+++ b/test/addons/init_signatures/init_exports.cc
@@ -1,0 +1,5 @@
+#include "init_test.h"
+void init(v8::Local<v8::Object> exports) {
+  node::test::setInitTag(exports);
+}
+NODE_MODULE(NODE_TEST_ADDON_NAME, init)

--- a/test/addons/init_signatures/init_exports_context.cc
+++ b/test/addons/init_signatures/init_exports_context.cc
@@ -1,0 +1,5 @@
+#include "init_test.h"
+void init(v8::Local<v8::Object> exports, v8::Local<v8::Context> context) {
+  node::test::setInitTag(exports);
+}
+NODE_MODULE(NODE_TEST_ADDON_NAME, init)

--- a/test/addons/init_signatures/init_exports_module.cc
+++ b/test/addons/init_signatures/init_exports_module.cc
@@ -1,0 +1,5 @@
+#include "init_test.h"
+void init(v8::Local<v8::Object> exports, v8::Local<v8::Object> module) {
+  node::test::setInitTag(exports);
+}
+NODE_MODULE(NODE_TEST_ADDON_NAME, init)

--- a/test/addons/init_signatures/init_exports_module_context.cc
+++ b/test/addons/init_signatures/init_exports_module_context.cc
@@ -1,0 +1,7 @@
+#include "init_test.h"
+void init(v8::Local<v8::Object> exports,
+          v8::Local<v8::Object> module,
+          v8::Local<v8::Context> context) {
+  node::test::setInitTag(exports);
+}
+NODE_MODULE(NODE_TEST_ADDON_NAME, init)

--- a/test/addons/init_signatures/init_exports_module_context_private.cc
+++ b/test/addons/init_signatures/init_exports_module_context_private.cc
@@ -1,0 +1,8 @@
+#include "init_test.h"
+void init(v8::Local<v8::Object> exports,
+          v8::Local<v8::Object> module,
+          v8::Local<v8::Context> context,
+          void * priv) {
+  node::test::setInitTag(exports);
+}
+NODE_MODULE(NODE_TEST_ADDON_NAME, init)

--- a/test/addons/init_signatures/init_exports_module_private.cc
+++ b/test/addons/init_signatures/init_exports_module_private.cc
@@ -1,0 +1,7 @@
+#include "init_test.h"
+void init(v8::Local<v8::Object> exports,
+          v8::Local<v8::Object> module,
+          void * priv) {
+  node::test::setInitTag(exports);
+}
+NODE_MODULE(NODE_TEST_ADDON_NAME, init)

--- a/test/addons/init_signatures/init_exports_private.cc
+++ b/test/addons/init_signatures/init_exports_private.cc
@@ -1,0 +1,5 @@
+#include "init_test.h"
+void init(v8::Local<v8::Object> exports, void * priv) {
+  node::test::setInitTag(exports);
+}
+NODE_MODULE(NODE_TEST_ADDON_NAME, init)

--- a/test/addons/init_signatures/init_test.h
+++ b/test/addons/init_signatures/init_test.h
@@ -1,0 +1,24 @@
+#ifndef NODE_TEST_ADDON_INIT_TEST_H
+# define NODE_TEST_ADDON_INIT_TEST_H
+
+#include <node.h>
+
+namespace node { namespace test {
+
+inline
+void
+set(v8::Handle<v8::Object> obj, char const* name, bool value) {
+    v8::Isolate * isolate = v8::Isolate::GetCurrent();
+    obj->Set(
+        v8::String::NewFromUtf8(isolate, name),
+        v8::Boolean::New(isolate, value));
+}
+
+inline
+void
+setInitTag(v8::Handle<v8::Object> obj) {
+  set(obj, "initialized", true);
+}
+
+}}  // end of namespace node::test
+#endif // NODE_TEST_ADDON_INIT_TEST_H

--- a/test/addons/init_signatures/test.js
+++ b/test/addons/init_signatures/test.js
@@ -1,0 +1,16 @@
+var assert = require('assert')
+  , path   = require('path')
+  , i, name, addon
+  , signatures = [ ['exports']
+                 , ['exports', 'module']
+                 , ['exports', 'context']
+                 , ['exports', 'private']
+                 , ['exports', 'module', 'private']
+                 , ['exports', 'module', 'context']
+                 , ['exports', 'module', 'context', 'private']
+                 ];
+for (i in signatures) {
+  name  = 'init_' + signatures[i].join('_');
+  addon = require('./build/Release/' + name);
+  assert.ok(addon.initialized);
+}

--- a/test/addons/repl-domain-abort/binding.cc
+++ b/test/addons/repl-domain-abort/binding.cc
@@ -3,7 +3,7 @@
 
 using v8::Function;
 using v8::FunctionCallbackInfo;
-using v8::Handle;
+using v8::Local;
 using v8::HandleScope;
 using v8::Isolate;
 using v8::Object;
@@ -19,8 +19,8 @@ void Method(const FunctionCallbackInfo<Value>& args) {
                      NULL);
 }
 
-void init(Handle<Object> target) {
-  NODE_SET_METHOD(target, "method", Method);
+void init(Local<Object> exports) {
+  NODE_SET_METHOD(exports, "method", Method);
 }
 
 NODE_MODULE(binding, init);

--- a/test/addons/smalloc-alloc/binding.cc
+++ b/test/addons/smalloc-alloc/binding.cc
@@ -21,7 +21,7 @@ void HasExternalData(const FunctionCallbackInfo<Value>& args) {
       node::smalloc::HasExternalData(args.GetIsolate(), args[0].As<Object>()));
 }
 
-void init(Handle<Object> target) {
+void init(Local<Object> target) {
   NODE_SET_METHOD(target, "alloc", Alloc);
   NODE_SET_METHOD(target, "dispose", Dispose);
   NODE_SET_METHOD(target, "hasExternalData", HasExternalData);


### PR DESCRIPTION
Stop discarding the addon init function signature. Instead capture it at compile-time and provide a suitable adapter, thus restoring type safety.

Doing so uncovered a bug-to-happen: The old `addon_register_func` declared the module argument with type `Handle<Value>` instead of `Handle<Object>`. This only compiled because of the discarded type information. It only worked because it exploited numerous v8 implementation details. It also exposed a few diverged prototypes of `Initialize(...)` functions. Both is fixed in this patch.

The new init function handling makes a few things easier:
- Builtin modules had an "unused" module argument which is no longer neccessary.
- We no longer have to deal with context aware modules seperatly. It's all the same.
